### PR TITLE
Add Lispworks support

### DIFF
--- a/exit-hooks.lisp
+++ b/exit-hooks.lisp
@@ -2,7 +2,7 @@
 
 (in-package #:exit-hooks)
 
-#-(or sbcl ccl ecl abcl allegro clisp cmu)
+#-(or sbcl ccl ecl abcl allegro clisp cmu lispworks)
 (error "Sorry, not implement for ~a. If you can provide exit-hooks for your implementation, please contact me at icerove@gmail.com~%" (lisp-implementation-type))
 
 #+abcl
@@ -11,7 +11,7 @@
 
   (defun %abcl-exit-hook-controller ()
     (mapc #'funcall *abcl-exit-hooks*))
-  
+
   (defparameter *exit-hook-thread*
     (java:jnew-runtime-class "ExitHookThread" :superclass "java.lang.Thread"
 			     :methods `(("run" :void () ,#'(lambda (this)
@@ -20,6 +20,7 @@
   (java:jcall "addShutdownHook" (java:jstatic "getRuntime" "java.lang.Runtime")
 	      (java:jnew *exit-hook-thread*)))
 
+#-lispworks
 (define-symbol-macro *exit-hooks*
     #+sbcl sb-ext:*exit-hooks*
     #+ccl ccl:*lisp-cleanup-functions*
@@ -29,7 +30,19 @@
     #+clisp custom:*fini-hooks*
     #+cmu lisp::*cleanup-functions*)
 
+#+lispworks
+(defvar *exit-hooks* nil)
+
+#+lispworks
+(defun lw-exit-action ()
+  (dolist (hook *exit-hooks*)
+    (funcall hook)))
+
+#+lispworks
+(lw:define-action "When quitting image" "Run exit hooks"
+  'lw-exit-action)
+
 (defun add-exit-hook (func)
-  (push #+allegro (list 'funcall func) 
+  (push #+allegro (list 'funcall func)
 	#-allegro func
         *exit-hooks*))


### PR DESCRIPTION
Test plan: Loaded in Lispworks, ran `(exit-hooks:add-exit-hook (lambda () (format t "hello world~%"))) `.

Then ran `(quit)` and saw hello world being printed.

I suspect the hooks won't run if it is exiting in unpleasant circumstances, but I think that should be true of the other exit hooks too.